### PR TITLE
Introducing Business::Schemas::Product

### DIFF
--- a/business/Gemfile.lock
+++ b/business/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    business (0.1.0)
+    business (0.2.0)
       dry-monads (~> 1.3)
-      dry-schema (~> 1.10)
+      dry-schema (~> 1.13)
 
 GEM
   remote: https://rubygems.org/
@@ -20,7 +20,7 @@ GEM
       zeitwerk (~> 2.6)
     dry-inflector (1.0.0)
     dry-initializer (3.1.1)
-    dry-logic (1.4.0)
+    dry-logic (1.5.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0, < 2)
       zeitwerk (~> 2.6)
@@ -28,12 +28,12 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.0, < 2)
       zeitwerk (~> 2.6)
-    dry-schema (1.12.0)
+    dry-schema (1.13.0)
       concurrent-ruby (~> 1.0)
-      dry-configurable (~> 1.0, < 2)
+      dry-configurable (~> 1.0, >= 1.0.1)
       dry-core (~> 1.0, < 2)
       dry-initializer (~> 3.0)
-      dry-logic (>= 1.4, < 2)
+      dry-logic (>= 1.5, < 2)
       dry-types (>= 1.7, < 2)
       zeitwerk (~> 2.6)
     dry-types (1.7.0)

--- a/business/business.gemspec
+++ b/business/business.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   spec.add_dependency 'dry-monads', '~> 1.3'
-  spec.add_dependency 'dry-schema', '~> 1.10'
+  spec.add_dependency 'dry-schema', '~> 1.13'
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/business/lib/business/schemas.rb
+++ b/business/lib/business/schemas.rb
@@ -8,3 +8,4 @@ module Business
 end
 
 require_relative 'schemas/base_model'
+require_relative 'schemas/product'

--- a/business/lib/business/schemas/product.rb
+++ b/business/lib/business/schemas/product.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Business
+  module Schemas
+    # Business::Schemas::Product is just the same as the BaseModel but
+    # just having a different name
+    Product = BaseModel.dup.freeze
+  end
+end

--- a/business/lib/business/version.rb
+++ b/business/lib/business/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Business
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/business/spec/business/integration/schemas/product_spec.rb
+++ b/business/spec/business/integration/schemas/product_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe Business::Schemas::Product do
+  it { expect(described_class).to be_a(Dry::Schema::Params) }
+end

--- a/business/spec/business/unit/schemas/base_model_spec.rb
+++ b/business/spec/business/unit/schemas/base_model_spec.rb
@@ -1,55 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'shared_examples_for_base_model'
+
 RSpec.describe Business::Schemas::BaseModel do
-  let(:payload) do
-    { 'id' => uuid }
-  end
-
-  let(:result) { subject.call(payload) }
-
-  context 'when having a Valid Schema' do
-    let(:uuid) { SecureRandom.uuid }
-
-    it { expect(result).to be_success }
-    it { expect(result.to_h).to match(id: uuid) }
-
-    context 'when used as monad' do
-      it do
-        monad = result.to_monad
-        expect(monad).to be_a Dry::Monads::Result
-        expect(monad.value!).to be(result)
-      end
-    end
-  end
-
-  context 'when having an Invalid schemas' do
-    context 'when id is not a valid UUIDv4' do
-      let(:uuid) { SecureRandom.hex }
-
-      it do
-        expect(result).to be_failure
-        expect(result.errors.to_h).to match(id: ['is not a valid UUID'])
-      end
-    end
-
-    context 'when id is empty' do
-      let(:uuid) { '' }
-
-      it do
-        expect(result).to be_failure
-        expect(result.errors.to_h).to match(id: ['must be filled'])
-      end
-    end
-
-    context 'when having an empty payload' do
-      let(:payload) do
-        {}
-      end
-
-      it do
-        expect(result).to be_failure
-        expect(result.errors.to_h).to match(id: ['is missing'])
-      end
-    end
-  end
+  it_behaves_like 'an schema based on BaseModel', 'Business::Schemas::BaseModel'
 end

--- a/business/spec/business/unit/schemas/product_spec.rb
+++ b/business/spec/business/unit/schemas/product_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require_relative 'shared_examples_for_base_model'
+
+RSpec.describe Business::Schemas::Product do
+  it_behaves_like 'an schema based on BaseModel', 'Business::Schemas::Product'
+end

--- a/business/spec/business/unit/schemas/shared_examples_for_base_model.rb
+++ b/business/spec/business/unit/schemas/shared_examples_for_base_model.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'an schema based on BaseModel' do |class_name|
+  describe class_name.to_s do
+    subject(:result) do
+      described_class.call(payload)
+    end
+
+    let(:payload) do
+      { 'id' => uuid }
+    end
+
+    context 'when having a Valid Schema' do
+      let(:uuid) { SecureRandom.uuid }
+
+      it { expect(result).to be_success }
+      it { expect(result.to_h).to match(id: uuid) }
+      it { expect(result.errors.to_h).to be_empty }
+
+      context 'with extra keys, they will be ignored' do
+        let(:payload) do
+          {
+            'id' => uuid,
+            'extra' => 'will be ignored'
+          }
+        end
+
+        it { expect(result).to be_success }
+        it { expect(result.to_h).to match(id: uuid) }
+        it { expect(result.errors.to_h).to be_empty }
+      end
+
+      context 'when used as monad' do
+        it do
+          monad = result.to_monad
+          expect(monad).to be_a Dry::Monads::Result
+          expect(monad.value!).to be(result)
+        end
+      end
+    end
+
+    context 'when having an Invalid schemas' do
+      context 'when id is not a valid UUIDv4' do
+        let(:uuid) { SecureRandom.hex }
+
+        it { expect(result).to be_failure }
+        it { expect(result.errors.to_h).to match(id: ['is not a valid UUID']) }
+        # Dear maintainer, this is the expected behavior, it always was.
+        it { expect(result.to_h).to match(id: uuid) }
+        # Even if the schema has errors, the data produced by `to_h` will
+        # include the "wrong" fields and their values are *not* `nil` either.
+      end
+
+      context 'when id is empty' do
+        let(:uuid) { '' }
+
+        it { expect(result).to be_failure }
+        it { expect(result.errors.to_h).to match(id: ['must be filled']) }
+        it { expect(result.to_h).to match(id: uuid) }
+      end
+
+      context 'when having an empty payload' do
+        let(:payload) do
+          {}
+        end
+
+        it { expect(result).to be_failure }
+        it { expect(result.errors.to_h).to match(id: ['is missing']) }
+        it { expect(result.to_h).to match({}) }
+      end
+
+      context 'when having extra keys, they will be ignored' do
+        let(:payload) do
+          { 'not_expected' => 'will_be_ignored' }
+        end
+
+        it { expect(result).to be_failure }
+        it { expect(result.errors.to_h).to match(id: ['is missing']) }
+        it { expect(result.to_h).to match({}) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Which is similar to `Business::Schemas::BaseModel` we are just changing the name in order to make it more accessible to our consumers.

Since we Product is based on `BaseModel` it looks like a good idea to introduce a shared example for both of them, so we don't repeat ourselves.