### PR TITLE
Business::Api now uses Business::Schemas::Product

### DIFF
--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: ../business
   specs:
-    business (0.1.0)
+    business (0.2.0)
       dry-monads (~> 1.3)
-      dry-schema (~> 1.10)
+      dry-schema (~> 1.13)
 
 PATH
   remote: .

--- a/api/business-api.gemspec
+++ b/api/business-api.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = 'business-api'
-  spec.version = '0.0.1'
+  spec.version = '0.1.0'
   spec.authors = ['esparta']
   spec.email = ['rubyconf2022.demo@esparta.co']
 

--- a/api/lib/business/api.rb
+++ b/api/lib/business/api.rb
@@ -12,7 +12,7 @@ module Business
 
     scope :v1 do
       get 'products/:id' do
-        result = Business::Schemas::BaseModel.(params.slice(:id))
+        result = Business::Schemas::Product.(params.slice(:id))
         case result.to_monad
         in Success(id:)
           json(id: id)


### PR DESCRIPTION
Instead of the more generic `Business::Schemas::BaseModel`. This is not changing the behavior of the gem.

Bumping version just for the sake of having track of the change.