### PR TITLE
Introducing Business::Schemas::AvailabilityCalendar

### DIFF
--- a/business/.rubocop.yml
+++ b/business/.rubocop.yml
@@ -1,1 +1,7 @@
 inherit_from: ../.rubocop.yml
+
+Naming/VariableName:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false

--- a/business/Gemfile.lock
+++ b/business/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    business (0.2.0)
+    business (0.3.0)
       dry-monads (~> 1.3)
       dry-schema (~> 1.13)
 

--- a/business/lib/business/schemas.rb
+++ b/business/lib/business/schemas.rb
@@ -4,6 +4,7 @@ require 'dry/schema'
 require 'dry/monads'
 
 Dry::Schema.load_extensions(:monads)
+require_relative 'types'
 
 module Business
   # Business::Schemas is the main container for the schemas used
@@ -14,3 +15,5 @@ end
 
 require_relative 'schemas/base_model'
 require_relative 'schemas/product'
+require_relative 'schemas/units'
+require_relative 'schemas/availability_calendar'

--- a/business/lib/business/schemas/availability_calendar.rb
+++ b/business/lib/business/schemas/availability_calendar.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Business
+  module Schemas
+    # Business::Schemas::AvailabilityCalendar
+    # our schema matching the specs the Octo Travel API
+    # https://docs.octo.travel/docs/octo/11e01f57f9cb0-availability-calendar
+    # spec:
+    # {
+    #   'id' => { type: uuid, :required },
+    #   'optionId' => { type: :string, :required },
+    #   'localDateStart' => { type: string, format: yyyy-mm-dd, :required },
+    #   'localDateEnd' => { type: string, format: yyyy-mm-dd, :required },
+    #   'unitd' => [ # composed by Schemas::Units
+    #      {
+    #        'id' => { type: uuid, :required },
+    #        'quantity' => { type: :integer, :required }
+    #      }
+    #   ]
+    # }
+    AvailabilityCalendar = Dry::Schema.JSON do
+      required(:productId).filled(:uuid_v4?)
+      required(:optionId).filled(:string)
+      required(:localDateStart).value(Types::JSON::Date)
+      required(:localDateEnd).value(Types::JSON::Date)
+      optional(:units).array(Units)
+    end
+  end
+end

--- a/business/lib/business/schemas/units.rb
+++ b/business/lib/business/schemas/units.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'dry/schema'
+
+module Business
+  module Schemas
+    # Business::Schemas::Units - used to compose multiple other schemas
+    # spec:
+    #   { 'id' => { type: uuid },
+    #     'quantity' => { type: integer, minValue: 1 }
+    #   }
+    Units = Dry::Schema.JSON(parent: BaseModel) do
+      required(:quantity).value(:integer, gt?: 0)
+    end
+  end
+end

--- a/business/lib/business/types.rb
+++ b/business/lib/business/types.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'dry/types'
+
+module Types
+  include Dry::Types()
+end

--- a/business/lib/business/version.rb
+++ b/business/lib/business/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Business
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/business/spec/business/integration/schemas/availability_calendar_spec.rb
+++ b/business/spec/business/integration/schemas/availability_calendar_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'dry/monads'
+require 'date'
+
+RSpec.describe Business::Schemas::AvailabilityCalendar do
+  subject(:availability) { described_class.(input) }
+
+  let(:monad) do
+    case availability.to_monad
+    in Dry::Monads::Result::Success(productId:, optionId:, **rest)
+      date_start_in_usa = rest[:localDateStart].strftime('%m/%d/%Y')
+      date_end_in_usa = rest[:localDateEnd].strftime('%m/%d/%Y')
+      "<#{productId}>-<#{optionId}>-(#{date_start_in_usa}..#{date_end_in_usa})"
+    in Dry::Monads::Result::Failure(productId:, optionId:)
+      'Something went wrong'
+    end
+  end
+
+  context 'when input is valid (Success)' do
+    let(:product_id) { SecureRandom.uuid }
+    let(:option_id) { SecureRandom.alphanumeric }
+    let(:input) do
+      {
+        'productId' => product_id,
+        'optionId' => option_id,
+        'localDateStart' => '2022-11-29',
+        'localDateEnd' => '2022-12-01'
+      }
+    end
+
+    it do
+      expect(
+        monad
+      ).to eq("<#{product_id}>-<#{option_id}>-(11/29/2022..12/01/2022)")
+    end
+  end
+
+  context 'when input is not valid (Failure)' do
+    let(:product_id) { SecureRandom.hex }
+    let(:option_id) { SecureRandom.alphanumeric }
+    let(:input) do
+      {
+        'productId' => product_id,
+        'optionId' => option_id
+      }
+    end
+
+    it { expect(monad).to eq('Something went wrong') }
+  end
+end

--- a/business/spec/business/unit/schemas/availability_calendar_spec.rb
+++ b/business/spec/business/unit/schemas/availability_calendar_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+RSpec.describe Business::Schemas::AvailabilityCalendar do
+  subject(:availability) { described_class.(input) }
+
+  context 'when input is invalid (Failure) because units is not an array' do
+    let(:product_id) { SecureRandom.uuid }
+    let(:option_id) { SecureRandom.alphanumeric }
+    let(:local_date_start) { '2022-11-29' }
+    let(:local_date_end) { '2022-12-01' }
+    let(:local_date_start_as_date) { Date.parse(local_date_start) }
+    let(:local_date_end_as_date) { Date.parse(local_date_end) }
+    let(:units) do
+      { 'id' => 'AABB', 'quantity' => 1 }
+    end
+    let(:input) do
+      {
+        'productId' => product_id,
+        'optionId' => option_id,
+        'localDateStart' => local_date_start,
+        'localDateEnd' => local_date_end,
+        'units' => units
+      }
+    end
+
+    it { expect(availability).to be_failure }
+
+    it do
+      expect(availability.errors.to_h).to match(units: ['must be an array'])
+    end
+
+    it do
+      expect(
+        availability.to_h
+      ).to match(
+        productId: product_id,
+        optionId: option_id,
+        localDateStart: local_date_start_as_date,
+        localDateEnd: local_date_end_as_date,
+        units: { 'id' => 'AABB', 'quantity' => 1 }
+      )
+    end
+  end
+
+  context 'when input is invalid (Failure)' do
+    let(:input) do
+      {}
+    end
+
+    it { expect(availability).to be_failure }
+    it { expect(availability.to_h).to eq({}) }
+
+    it do
+      expect(
+        availability.errors.to_h
+      ).to match(
+        productId: ['is missing'],
+        optionId: ['is missing'],
+        localDateStart: ['is missing'],
+        localDateEnd: ['is missing']
+      )
+    end
+  end
+
+  context 'when input is valid (Success)' do
+    let(:product_id) { SecureRandom.uuid }
+    let(:option_id) { SecureRandom.alphanumeric }
+    let(:local_date_start) { '2022-11-29' }
+    let(:local_date_end) { '2022-12-01' }
+    let(:local_date_start_as_date) { Date.parse(local_date_start) }
+    let(:local_date_end_as_date) { Date.parse(local_date_end) }
+    let(:unit_id) { SecureRandom.uuid }
+    let(:units) do
+      [
+        { 'id' => unit_id, 'quantity' => 1 }
+      ]
+    end
+    let(:input) do
+      {
+        'productId' => product_id,
+        'optionId' => option_id,
+        'localDateStart' => local_date_start,
+        'localDateEnd' => local_date_end,
+        'units' => units
+      }
+    end
+
+    it { expect(availability).to be_success }
+    it { expect(availability.errors.to_h).to be_empty }
+
+    it do
+      expect(
+        availability.to_h
+      ).to match(
+        productId: product_id,
+        optionId: option_id,
+        localDateStart: local_date_start_as_date,
+        localDateEnd: local_date_end_as_date,
+        units: [{ id: unit_id, quantity: 1 }]
+      )
+    end
+  end
+end

--- a/business/spec/business/unit/schemas/units_spec.rb
+++ b/business/spec/business/unit/schemas/units_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.describe Business::Schemas::Units do
+  subject(:units) { described_class.(input) }
+
+  let(:input) do
+    { 'id' => uuid, 'quantity' => quantity }
+  end
+
+  let(:uuid) { SecureRandom.uuid }
+
+  context 'when schema is not valid (Failure) because qty is not integer' do
+    let(:quantity) { 1.2 }
+
+    it { expect(units).to be_failure }
+
+    it do
+      expect(units.to_h).to match(id: uuid, quantity: quantity)
+    end
+
+    it do
+      expect(
+        units.errors.to_h
+      ).to match(quantity: ['must be an integer'])
+    end
+  end
+
+  context 'when schema is not valid (Failure) because qty < 1' do
+    let(:quantity) { 0 }
+
+    it { expect(units).to be_failure }
+
+    it do
+      expect(units.to_h).to match(id: uuid, quantity: quantity)
+    end
+
+    it do
+      expect(units.errors.to_h).to match(quantity: ['must be greater than 0'])
+    end
+  end
+
+  context 'when schema is not valid (Failure) because id is absent' do
+    let(:quantity) { 1 }
+    let(:input) do
+      { 'quantity' => quantity }
+    end
+
+    it { expect(units).to be_failure }
+    it { expect(units.to_h).to match(quantity: quantity) }
+    it { expect(units.errors.to_h).to match(id: ['is missing']) }
+  end
+
+  context 'when schema is not valid (Failure) because qty is absent' do
+    let(:input) do
+      { 'id' => uuid }
+    end
+
+    it { expect(units).to be_failure }
+    it { expect(units.to_h).to match(id: uuid) }
+    it { expect(units.errors.to_h).to match(quantity: ['is missing']) }
+  end
+
+  context 'when schema is valid (Success)' do
+    let(:quantity) { 1 }
+
+    it { expect(units).to be_success }
+    it { expect(units.errors.to_h).to be_empty }
+
+    it do
+      expect(units.to_h).to match(id: uuid, quantity: quantity)
+    end
+  end
+end


### PR DESCRIPTION
Creating an Schema matching the specification of an open API spec for travel agencies called `Octo Travel`, the Availabibly Calendar which is documented here:

https://docs.octo.travel/docs/octo/11e01f57f9cb0-availability-calendar

![image](https://user-images.githubusercontent.com/1037088/204165330-f5e75a1a-a314-48a1-a7e4-385fa82c3c92.png)


In `Business::Schemas::AvailabilityCalendar` we can see multiple aspects of `Dry::Schema` gem, including, but not limited to:

- Array specs
- reusing of Schemas (check `Business::Schemas::Units`)
- using custom types