### PR TITLE
Api: Using Contracts::Product instead of Schemas::Products

### DIFF
--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -1,14 +1,15 @@
 PATH
   remote: ../business
   specs:
-    business (0.2.0)
+    business (0.5.0)
       dry-monads (~> 1.3)
       dry-schema (~> 1.13)
+      dry-validation (~> 1.10)
 
 PATH
   remote: .
   specs:
-    business-api (0.1.0)
+    business-api (0.2.0)
       dry-monads (~> 1.3)
       dry-schema (~> 1.10)
       hanami-api (~> 0.2.0)
@@ -49,6 +50,12 @@ GEM
       dry-core (~> 1.0, < 2)
       dry-inflector (~> 1.0, < 2)
       dry-logic (>= 1.4, < 2)
+      zeitwerk (~> 2.6)
+    dry-validation (1.10.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0, < 2)
+      dry-initializer (~> 3.0)
+      dry-schema (>= 1.12, < 2)
       zeitwerk (~> 2.6)
     ffi (1.15.5)
     formatador (1.1.0)

--- a/api/business-api.gemspec
+++ b/api/business-api.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = 'business-api'
-  spec.version = '0.1.0'
+  spec.version = '0.2.0'
   spec.authors = ['esparta']
   spec.email = ['rubyconf2022.demo@esparta.co']
 

--- a/api/lib/business/api.rb
+++ b/api/lib/business/api.rb
@@ -4,6 +4,8 @@ require 'business'
 require 'dry/monads'
 require 'hanami/api'
 
+require_relative 'process_data_with_dates'
+
 module Business
   # Business::Api is our main application receiving the request
   # and returning data as JSON
@@ -12,8 +14,12 @@ module Business
 
     scope :v1 do
       get 'products/:id' do
-        result = Business::Schemas::Product.(params.slice(:id))
+        result = Business::Contracts::Product.(
+          params.slice(:id, :localDateStart, :localDateEnd)
+        )
         case result.to_monad
+        in Success(id:, localDateStart:, localDateEnd:)
+          json(ProcessDataWithDates.call(id, localDateStart, localDateEnd)) # rubocop:disable Naming/VariableName
         in Success(id:)
           json(id: id)
         in Failure(id:)

--- a/api/lib/business/process_data_with_dates.rb
+++ b/api/lib/business/process_data_with_dates.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Business
+  # Business::ProcessDataWithDates
+  class ProcessDataWithDates
+    class << self
+      def call(id, date_start, date_end)
+        {
+          id: id,
+          date_start: date_start.strftime('%s'),
+          date_end: date_end.strftime('%s')
+        }
+      end
+    end
+  end
+end

--- a/api/spec/business/unit/api_spec.rb
+++ b/api/spec/business/unit/api_spec.rb
@@ -30,6 +30,41 @@ RSpec.describe Business::Api do
       end
     end
 
+    # rubocop:disable RSpec/MultipleMemoizedHelpers
+    context 'when using an UUID & parameters (Success)' do
+      let(:request) do
+        {
+          'PATH_INFO' => path,
+          'REQUEST_METHOD' => request_method,
+          'QUERY_STRING' => query_string
+        }
+      end
+      let(:query_string) do
+        "localDateStart=#{date_start_as_string}&localDateEnd=#{date_end_as_string}"
+      end
+      let(:date_start_as_string) { '2022-11-29' }
+      let(:date_end_as_string) { '2022-12-01' }
+      let(:date_start_as_unix) do
+        Date.parse(date_start_as_string).strftime('%s')
+      end
+      let(:date_end_as_unix) do
+        Date.parse(date_end_as_string).strftime('%s')
+      end
+
+      let(:id) { SecureRandom.uuid }
+
+      it do
+        hash = {
+          id: id,
+          date_start: date_start_as_unix,
+          date_end: date_end_as_unix
+        }
+        body = [hash.to_json]
+        expect(api).to match([200, content_type, body])
+      end
+    end
+    # rubocop:enable RSpec/MultipleMemoizedHelpers
+
     context 'when not using an UUID (Failure)' do
       let(:id) { SecureRandom.random_number(100) }
 


### PR DESCRIPTION
With this we gain the ability to use dates parameters and a new branch of pattern matching